### PR TITLE
Quickfix for de-serialization

### DIFF
--- a/lib/sbn/formats.rb
+++ b/lib/sbn/formats.rb
@@ -115,7 +115,7 @@ module Sbn
           manager_name = val if key == 'ManagerVariableName'
           text_to_match = eval(val) if key == 'TextToMatch'
           options[key.to_sym] = val.to_i if key =~ /stdev_state_count/
-          thresholds = val.map {|e| e.to_f } if key == 'StateThresholds'
+          thresholds = val.split(',').map {|e| e.to_f } if key == 'StateThresholds'
         end
         states = var['outcome']
         table = []

--- a/lib/sbn/inference.rb
+++ b/lib/sbn/inference.rb
@@ -17,7 +17,7 @@ module Sbn
     # 
     # Optionally accepts a block that receives a number between 0 and 1 indicating
     # the percentage of completion. 
-    def query_variable(varname, callback = nil)
+    def query_variable(varname, sample_count = MCMC_DEFAULT_SAMPLE_COUNT, callback = nil)
       # keep track of number of times a state has been observed
       state_frequencies = {}
       varname = varname.to_underscore_sym
@@ -27,14 +27,14 @@ module Sbn
       e = generate_random_event
       relevant_evidence = e.reject {|key, val| @variables[key].set_in_evidence?(@evidence) }
 
-      MCMC_DEFAULT_SAMPLE_COUNT.times do |n|
+      sample_count.times do |n|
         state = e[varname]
         state_frequencies[state] += 1
 
         relevant_evidence.each do |vname, vstate|
           e[vname] = @variables[vname].get_random_state_with_markov_blanket(e)
         end
-        yield(n / MCMC_DEFAULT_SAMPLE_COUNT.to_f) if block_given?
+        yield(n / sample_count.to_f) if block_given?
       end
 
       # normalize results


### PR DESCRIPTION
String that contained variables' thresholds was previously treated as if it was Enumerable.
Also added an optional argument for mcmc sample count so noone can ever say i've made a pull request with one line changed.
